### PR TITLE
Fix #578 : open new tab in current directory

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -956,6 +956,7 @@ Always</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_open_tab_cwd_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>


### PR DESCRIPTION
The check-box for 'open new tab in current directory' in `data/prefs.glade` is not linked to the appropriate listener. This pull request fixes the issue by adding the appropriate listener to the check-box in the `prefs.glade` file
