### PR TITLE
Fix #619 : Unable to set default interpreter

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -913,6 +913,7 @@ Always</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="items" translatable="yes"/>
+                                        <signal name="changed" handler="on_default_shell_changed" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>


### PR DESCRIPTION
This pull request fixes https://github.com/Guake/guake/issues/619. The issue is similar to https://github.com/Guake/guake/issues/578 where the data in 'prefs.glade' has not been linked to the appropriate handler. In a similar manner the 'use as login shell' check-box is also not linked correctly.
