### PR TITLE
Fix #524: use VTE titles for tab names

### DIFF
--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -247,6 +247,11 @@ class PrefsCallbacks(object):
         """Changes the activity of start_fullscreen in gconf
         """
         self.client.set_bool(KEY('/general/start_fullscreen'), chk.get_active())
+        
+    def on_use_vte_titles_toggled(self, chk):
+        """Save `use_vte_titles` property value in gconf
+        """
+        self.client.set_bool(KEY('/general/use_vte_titles'), chk.get_active())
 
     def on_mouse_display_toggled(self, chk):
         """Set the 'appear on mouse display' preference in gconf. This


### PR DESCRIPTION
Fixes https://github.com/Guake/guake/issues/524. The handler was present in `prefs.glade` but was not present in `prefs.py`. Added the same to fix the issue.
