### PR TITLE
Fix #524 : run command as login shell

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -941,6 +941,7 @@ Always</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
+					<signal name="toggled" handler="on_use_login_shell_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>


### PR DESCRIPTION
Fix 'run command as login shell' by adding the appropriate handler in the `prefs.glade`
